### PR TITLE
clock_stm32f0_f3: Enable SYSCFG clock

### DIFF
--- a/drivers/clock_control/clock_stm32f0_f3.c
+++ b/drivers/clock_control/clock_stm32f0_f3.c
@@ -77,6 +77,11 @@ void config_enable_default_clocks(void)
 	/* Enable System Configuration Controller clock. */
 	LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_SYSCFG);
 #endif
+#else
+#if defined(CONFIG_USB_DC_STM32)
+	/* Enable System Configuration Controller clock. */
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
+#endif
 #endif /* !CONFIG_SOC_SERIES_STM32F3X */
 }
 


### PR DESCRIPTION
To remap USB IRQ, we need to enable
SYSCFG clock.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>