### PR TITLE
Upstream usb stm32n6 f

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -74,9 +74,42 @@ The Zephyr ``nucleo_n657x0_q`` board supports the following hardware features:
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB High Speed device               |
++-----------+------------+-------------------------------------+
 
 
 Other hardware features are not yet supported on this Zephyr port.
+
+USB:
+====
+
+The USB pin assignments on the STM32N657XX microcontroller are immutable. This means that the specific
+pins designated for USB functionality are fixed and cannot be changed or reassigned to other functions,
+ensuring consistent and reliable USB communication.
+
+USB PIN (IOs)
+=============
+
++------------------+--------------------------------------+
+| Name             | Description                          |
++==========================+==============================+
+| OTG1_HSDM        | USB OTG1 High-Speed Data- (negative) |
++--------------------------+------------------------------+
+| OTG1_HSDP        | USB OTG1 High-Speed Data+ (positive) |
++---------+-----------------+-----------------------------+
+| OTG1_ID          | USB OTG1 ID Pin                      |
++--------------------------+------------------------------+
+| OTG1_TXRTUNE     | USB OTG1 Transmit Retune             |
++---------+-----------------+-----------------------------+
+| OTG2_HSDM        | USB OTG2 High-Speed Data- (negative) |
++--------------------------+------------------------------+
+| OTG2_HSDP        | USB OTG2 High-Speed Data+ (positive) |
++---------+-----------------+-----------------------------+
+| OTG2_ID          | USB OTG2 ID Pin                      |
++--------------------------+------------------------------+
+| OTG2_TXRTUNE     | USB OTG2 Transmit Retune             |
++---------+-----------------+-----------------------------+
+
 
 The default configuration can be found in the defconfig file:
 :zephyr_file:`boards/st/nucleo_n657x0_q/nucleo_n657x0_q_defconfig`

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -50,6 +50,12 @@
 	};
 };
 
+&clk_hse {
+	hse-div2;
+	clock-frequency = <DT_FREQ_M(48)>;
+	status = "okay";
+};
+
 &clk_hsi {
 	hsi-div = <1>;
 	status = "okay";
@@ -116,5 +122,9 @@
 	pinctrl-0 = <&usart1_tx_pe5 &usart1_rx_pe6>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+zephyr_udc0: &usbotg_hs1 {
 	status = "okay";
 };

--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -6,6 +6,7 @@ flash: 1024
 supported:
   - gpio
   - uart
+  - usb_device
 vendor: st
 variants:
   nucleo_n657x0_q/stm32n657xx:

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -78,9 +78,42 @@ The Zephyr ``stm32n6570_dk`` board supports the following hardware features:
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB High Speed device               |
++-----------+------------+-------------------------------------+
 
 
 Other hardware features are not yet supported on this Zephyr port.
+
+USB:
+====
+
+The USB pin assignments on the STM32N657XX microcontroller are immutable. This means that the specific
+pins designated for USB functionality are fixed and cannot be changed or reassigned to other functions,
+ensuring consistent and reliable USB communication.
+
+USB PIN (IOs)
+=============
+
++------------------+--------------------------------------+
+| Name             | Description                          |
++==========================+==============================+
+| OTG1_HSDM        | USB OTG1 High-Speed Data- (negative) |
++--------------------------+------------------------------+
+| OTG1_HSDP        | USB OTG1 High-Speed Data+ (positive) |
++---------+-----------------+-----------------------------+
+| OTG1_ID          | USB OTG1 ID Pin                      |
++--------------------------+------------------------------+
+| OTG1_TXRTUNE     | USB OTG1 Transmit Retune             |
++---------+-----------------+-----------------------------+
+| OTG2_HSDM        | USB OTG2 High-Speed Data- (negative) |
++--------------------------+------------------------------+
+| OTG2_HSDP        | USB OTG2 High-Speed Data+ (positive) |
++---------+-----------------+-----------------------------+
+| OTG2_ID          | USB OTG2 ID Pin                      |
++--------------------------+------------------------------+
+| OTG2_TXRTUNE     | USB OTG2 Transmit Retune             |
++---------+-----------------+-----------------------------+
+
 
 The default configuration can be found in the defconfig file:
 :zephyr_file:`boards/st/stm32n6570_dk/stm32n6570_dk_defconfig`

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -34,6 +34,12 @@
 	};
 };
 
+&clk_hse {
+	hse-div2;
+	clock-frequency = <DT_FREQ_M(48)>;
+	status = "okay";
+};
+
 &clk_hsi {
 	hsi-div = <1>;
 	status = "okay";
@@ -100,5 +106,9 @@
 	pinctrl-0 = <&usart1_tx_pe5 &usart1_rx_pe6>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+zephyr_udc0: &usbotg_hs1 {
 	status = "okay";
 };

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -7,6 +7,7 @@ vendor: st
 supported:
   - gpio
   - uart
+  - usb_device
 variants:
   stm32n6570_dk/stm32n657xx:
     twister: false

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -71,9 +71,11 @@ static const struct stm32_pclken pclken[] = STM32_DT_INST_CLOCKS(0);
 #define USB_MAXIMUM_SPEED	DT_INST_PROP(0, maximum_speed)
 #endif
 
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)
 PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *usb_pcfg =
 					PINCTRL_DT_INST_DEV_CONFIG_GET(0);
+#endif
 
 #define USB_OTG_HS_EMB_PHY (DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) && \
 			    DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs))
@@ -118,6 +120,10 @@ static const struct gpio_dt_spec ulpi_reset =
 #define USB_OTG_SPEED_HIGH                     0U
 #define USB_OTG_SPEED_HIGH_IN_FULL             1U
 #endif /* CONFIG_SOC_SERIES_STM32L4X */
+
+#if defined(CONFIG_SOC_SERIES_STM32N6X)
+#define USB_USBPHYC_CR_FSEL_24MHZ USB_USBPHYC_CR_FSEL_1
+#endif
 
 #define EP0_MPS USB_OTG_MAX_EP0_SIZE
 
@@ -324,6 +330,14 @@ static int usb_dc_stm32_phy_specific_clock_enable(const struct device *const clk
 	 * with LL_PWR_EnableVDDUSB function (higher case)
 	 */
 	LL_PWR_EnableVDDUSB();
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	/* Enable Vdd USB voltage monitoring */
+	LL_PWR_EnableVddUSBMonitoring();
+	while (__HAL_PWR_GET_FLAG(PWR_FLAG_USB33RDY)) {
+		/* Wait for VDD33USB ready */
+	}
+	/* Enable VDDUSB */
+	LL_PWR_EnableVddUSB();
 #endif
 
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
@@ -402,12 +416,26 @@ static int usb_dc_stm32_clock_enable(void)
 	/* Both OTG HS and USBPHY sleep clock MUST be disabled here at the same time */
 	LL_AHB2_GRP1_DisableClockStopSleep(LL_AHB2_GRP1_PERIPH_OTG_HS ||
 						LL_AHB2_GRP1_PERIPH_USBPHY);
-#else
+#elif !defined(CONFIG_SOC_SERIES_STM32N6X)
 	LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 #endif
 
 #if USB_OTG_HS_EMB_PHY
+#if defined(CONFIG_SOC_SERIES_STM32N6X)
+	/* Reset specific configuration bits before setting new values */
+	USB1_HS_PHYC->USBPHYC_CR &= ~USB_USBPHYC_CR_FSEL_Msk;
+
+	/* Configure the USB PHY Control Register to operate in the High frequency "24 MHz"
+	 * by setting the Frequency Selection (FSEL) bits 4 and 5 to 10,
+	 * which ensures proper communication.
+	 */
+	USB1_HS_PHYC->USBPHYC_CR |= USB_USBPHYC_CR_FSEL_24MHZ;
+
+	/* Peripheral OTGPHY clock enable */
+	LL_AHB5_GRP1_EnableClock(LL_AHB5_GRP1_PERIPH_OTGPHY1);
+#else
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
+#endif
 #endif
 #endif /* USB_OTG_HS_ULPI_PHY */
 
@@ -424,12 +452,14 @@ static int usb_dc_stm32_clock_disable(void)
 	}
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_otghs_phy)
 	clock_control_off(clk, (clock_control_subsys_t)&phy_pclken[0]);
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	LL_AHB5_GRP1_DisableClock(LL_AHB5_GRP1_PERIPH_OTGPHY1);
 #endif
 
 	return 0;
 }
 
-#if defined(USB_OTG_FS) || defined(USB_OTG_HS)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs) || DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
 static uint32_t usb_dc_stm32_get_maximum_speed(void)
 {
 	/*
@@ -481,11 +511,7 @@ static int usb_dc_stm32_init(void)
 	usb_dc_stm32_state.pcd.Init.ep0_mps = PCD_EP0MPS_64;
 	usb_dc_stm32_state.pcd.Init.low_power_enable = 0;
 #else /* USB_OTG_FS || USB_OTG_HS */
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
-	usb_dc_stm32_state.pcd.Instance = USB_OTG_HS;
-#else
-	usb_dc_stm32_state.pcd.Instance = USB_OTG_FS;
-#endif
+	usb_dc_stm32_state.pcd.Instance = (USB_OTG_GlobalTypeDef *)USB_BASE_ADDRESS;
 	usb_dc_stm32_state.pcd.Init.dev_endpoints = USB_NUM_BIDIR_ENDPOINTS;
 	usb_dc_stm32_state.pcd.Init.speed = usb_dc_stm32_get_maximum_speed();
 #if USB_OTG_HS_EMB_PHY
@@ -529,12 +555,14 @@ static int usb_dc_stm32_init(void)
 	}
 #endif
 
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)
 	LOG_DBG("Pinctrl signals configuration");
 	ret = pinctrl_apply_state(usb_pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
 		LOG_ERR("USB pinctrl setup failed (%d)", ret);
 		return ret;
 	}
+#endif
 
 	LOG_DBG("HAL_PCD_Init");
 	status = HAL_PCD_Init(&usb_dc_stm32_state.pcd);

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -450,6 +450,27 @@
 			interrupts = <168 0>;
 			status = "disabled";
 		};
+
+		usbotg_hs1: otghs@58040000 {
+			compatible = "st,stm32n6-otghs", "st,stm32-otghs";
+			reg = <0x58040000 0x2000>;
+			interrupts = <177 0>;
+			interrupt-names = "otghs";
+			num-bidir-endpoints = <9>;
+			ram-size = <4096>;
+			maximum-speed = "high-speed";
+			clocks = <&rcc STM32_CLOCK(AHB5, 26)>,
+				 <&rcc STM32_SRC_HSE OTGPHY1CKREF_SEL(1)>;
+			phys = <&usbphyc1>;
+			status = "disabled";
+		};
+
+		usbphyc1: usbphyc@5803fc00 {
+			compatible = "st,stm32-usbphyc";
+			reg = <0x5803FC00 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 27)>;
+			#phy-cells = <0>;
+		};
 	};
 };
 

--- a/dts/bindings/usb/st,stm32-otghs-common.yaml
+++ b/dts/bindings/usb/st,stm32-otghs-common.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2024, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for STM32 OTGHS controller
+
+include: [usb-ep.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  ram-size:
+    type: int
+    required: true
+    description: |
+      Size of USB dedicated RAM. STM32 SOC's reference
+      manual defines a shared FIFO size.
+
+  phys:
+    type: phandle
+    description: PHY provider specifier
+
+  clocks:
+    required: true

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -1,35 +1,16 @@
 # Copyright (c) 2017, I-SENSE group of ICCS
+# Copyright (c) 2024, STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
 description: STM32 OTGHS controller
 
 compatible: "st,stm32-otghs"
 
-include: [usb-ep.yaml, pinctrl-device.yaml]
+include: st,stm32-otghs-common.yaml
 
 properties:
-  reg:
-    required: true
-
-  interrupts:
-    required: true
-
   pinctrl-0:
     required: true
 
   pinctrl-names:
-    required: true
-
-  ram-size:
-    type: int
-    required: true
-    description: |
-      Size of USB dedicated RAM. STM32 SOC's reference
-      manual defines a shared FIFO size.
-
-  phys:
-    type: phandle
-    description: PHY provider specifier
-
-  clocks:
     required: true

--- a/dts/bindings/usb/st,stm32n6-otghs.yaml
+++ b/dts/bindings/usb/st,stm32n6-otghs.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2024, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32N6 OTGHS controller
+
+  In the STM32N6 series, the `pinctrl-0` and `pinctrl-names` properties are not required
+  for the USB OTG HS peripheral configuration. This is because the pin multiplexing
+  for the USB OTG HS peripheral are handled automatically by the hardware.
+
+compatible: "st,stm32n6-otghs"
+
+include: st,stm32-otghs-common.yaml

--- a/west.yml
+++ b/west.yml
@@ -238,7 +238,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 1d1f81866ccbaa6e84e9960ed763e005d1e45560
+      revision: ea773e786a9f78d779480b5cec8c3c98828f2127
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Add the support of the USB OTG HS
Enable the USB OTG HS node of the stm32n6570_dk and nucleo_n657x0_q boards.